### PR TITLE
First test at changing the Ubuntu verification to make sure it doesn't need updating all the time

### DIFF
--- a/cookbooks/learn-the-basics-ubuntu/recipes/setup.rb
+++ b/cookbooks/learn-the-basics-ubuntu/recipes/setup.rb
@@ -16,10 +16,17 @@ execute 'install Chef DK' do
 end
 
 control_group 'validate Chef DK installation' do
-  control 'validate version' do
-    describe command('chef --version') do
-      its (:stdout) { should match /Chef Development Kit Version: #{chefdk_version}/ }
-      its (:stdout) { should match /chef-client version: #{chef_client_version}/ }
+  # control 'validate version' do
+  #   describe command('chef --version') do
+  #     its (:stdout) { should match /Chef Development Kit Version: #{chefdk_version}/ }
+  #     its (:stdout) { should match /chef-client version: #{chef_client_version}/ }
+  #   end
+  # end
+
+  control 'validate successful run' do
+    describe command('chef verify') do
+      its (:stdout) { should match /Verification of .+ succeeded/ }
+      its (:stdout) { should_not match /Verification of .+ failed/ }
     end
   end
 end


### PR DESCRIPTION
\cc @tpetchel 

We're running the learn-chef cookbooks now as acceptance tests during our Chef release.  The tests are currently failing because the ChefDK installed from the `current` channel has an updated version of Chef packaged into it.

This is going to happen _extremely_ regularly.  We update dependencies all the time.  I understand that this cookbook is supposed to mimic the learn chef workflow but lets talk and figure out a way to make sure we're using appropriate validation.