### PR TITLE
Updating the lesson1 regex assertion to work with both Chef <= 12.7 and >= 12.8

### DIFF
--- a/cookbooks/learn-the-basics-rhel/recipes/lesson1.rb
+++ b/cookbooks/learn-the-basics-rhel/recipes/lesson1.rb
@@ -64,8 +64,6 @@ step2_matchers = [
   /\s{2}* file\[\/tmp\/motd\] action create/,
   /\s{4}\- create new file \/tmp\/motd/,
   /\s{4}\- update content in file \/tmp\/motd from none to .+/,
-  /\s{4}\-\-\- \/tmp\/motd/,
-  /\s{4}\+\+\+ \/tmp\/\.motd/,
   /\s{4}\+hello world/,
   /\s{4}\- restore selinux security context/,
   /Running handlers:/,

--- a/cookbooks/learn-the-basics-ubuntu/recipes/lesson1.rb
+++ b/cookbooks/learn-the-basics-ubuntu/recipes/lesson1.rb
@@ -64,8 +64,6 @@ step2_matchers = [
   /\s{2}* file\[\/tmp\/motd\] action create/,
   /\s{4}\- create new file \/tmp\/motd/,
   /\s{4}\- update content in file \/tmp\/motd from none to .+/,
-  /\s{4}\-\-\- \/tmp\/motd/,
-  /\s{4}\+\+\+ \/tmp\/\.motd/,
   /\s{4}\+hello world/,
   /Running handlers:/,
   /Running handlers complete/,


### PR DESCRIPTION
Chef 12.7 outputs:

```
--- /tmp/motd	2016-02-17 04:48:47.262768000 +0000
+++ /tmp/.motd20160217-2134-1qrt1h6	2016-02-17 04:48:47.262768000 +0000
```

Chef 12.8 outputs:

```
--- /tmp/motd	2016-02-17 04:48:47.262768000 +0000
+++ /tmp/.chef-motd20160217-2134-1qrt1h6	2016-02-17 04:48:47.262768000 +0000
```

With all the other assertions in here, greping on this specific string seems less useful if its going to change between Chef versions.