### PR TITLE
Specify the log level we are testing against

### DIFF
--- a/cookbooks/learn-the-basics-rhel/recipes/lesson1.rb
+++ b/cookbooks/learn-the-basics-rhel/recipes/lesson1.rb
@@ -38,7 +38,7 @@ end
 
 workflow_task '1.2.1' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.2.2' do
@@ -48,7 +48,7 @@ end
 
 workflow_task '1.2.3' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 step2_matchers = [
@@ -111,7 +111,7 @@ end
 
 workflow_task '1.3.1' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.3.2' do
@@ -145,7 +145,7 @@ end
 
 workflow_task '1.4.1' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.4.2' do
@@ -183,7 +183,7 @@ end
 
 workflow_task '1.5.1' do
   cwd working
-  command 'chef-client --local-mode goodbye.rb --no-color --force-formatter'
+  command 'chef-client --local-mode goodbye.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.5.2' do

--- a/cookbooks/learn-the-basics-rhel/recipes/lesson2.rb
+++ b/cookbooks/learn-the-basics-rhel/recipes/lesson2.rb
@@ -34,13 +34,13 @@ end
 # Run chef-client.
 workflow_task '2.1.1' do
   cwd working
-  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 # Run chef-client again.
 workflow_task '2.1.2' do
   cwd working
-  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 f2_1_1 = stdout_file(cache, '2.1.1')
@@ -82,7 +82,7 @@ end
 # Run chef-client.
 workflow_task '2.2.1' do
   cwd working
-  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 f2_2_1 = stdout_file(cache, '2.2.1')
@@ -128,7 +128,7 @@ end
 # Run chef-client.
 workflow_task '2.3.1' do
   cwd working
-  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 f2_3_1 = stdout_file(cache, '2.3.1')

--- a/cookbooks/learn-the-basics-rhel/recipes/lesson3.rb
+++ b/cookbooks/learn-the-basics-rhel/recipes/lesson3.rb
@@ -109,7 +109,7 @@ end
 # Run chef-client.
 workflow_task '3.4.1' do
   cwd repo
-  command "sudo chef-client --local-mode --runlist 'recipe[learn_chef_httpd]' --no-color --force-formatter"
+  command "sudo chef-client --local-mode --runlist 'recipe[learn_chef_httpd]' --no-color --force-formatter --log_level warn"
 end
 
 f3_4_1 = stdout_file(cache, '3.4.1')

--- a/cookbooks/learn-the-basics-ubuntu/recipes/lesson1.rb
+++ b/cookbooks/learn-the-basics-ubuntu/recipes/lesson1.rb
@@ -38,7 +38,7 @@ end
 
 workflow_task '1.2.1' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.2.2' do
@@ -48,7 +48,7 @@ end
 
 workflow_task '1.2.3' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 step2_matchers = [
@@ -110,7 +110,7 @@ end
 
 workflow_task '1.3.1' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.3.2' do
@@ -144,7 +144,7 @@ end
 
 workflow_task '1.4.1' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.4.2' do
@@ -182,7 +182,7 @@ end
 
 workflow_task '1.5.1' do
   cwd working
-  command 'chef-client --local-mode goodbye.rb --no-color --force-formatter'
+  command 'chef-client --local-mode goodbye.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.5.2' do

--- a/cookbooks/learn-the-basics-ubuntu/recipes/lesson2.rb
+++ b/cookbooks/learn-the-basics-ubuntu/recipes/lesson2.rb
@@ -39,13 +39,13 @@ end
 # Run chef-client.
 workflow_task '2.1.1' do
   cwd working
-  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 # Run chef-client again.
 workflow_task '2.1.2' do
   cwd working
-  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 f2_1_1 = stdout_file(cache, '2.1.1')
@@ -93,7 +93,7 @@ end
 # Run chef-client.
 workflow_task '2.2.1' do
   cwd working
-  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 f2_2_1 = stdout_file(cache, '2.2.1')
@@ -143,7 +143,7 @@ end
 # Run chef-client.
 workflow_task '2.3.1' do
   cwd working
-  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'sudo chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 f2_3_1 = stdout_file(cache, '2.3.1')

--- a/cookbooks/learn-the-basics-ubuntu/recipes/lesson3.rb
+++ b/cookbooks/learn-the-basics-ubuntu/recipes/lesson3.rb
@@ -117,7 +117,7 @@ end
 # Run chef-client.
 workflow_task '3.4.1' do
   cwd repo
-  command "sudo chef-client --local-mode --runlist 'recipe[learn_chef_apache2]' --no-color --force-formatter"
+  command "sudo chef-client --local-mode --runlist 'recipe[learn_chef_apache2]' --no-color --force-formatter --log_level warn"
 end
 
 f3_4_1 = stdout_file(cache, '3.4.1')

--- a/cookbooks/learn-the-basics-windows/recipes/lesson1.rb
+++ b/cookbooks/learn-the-basics-windows/recipes/lesson1.rb
@@ -44,7 +44,7 @@ end
 
 workflow_task '1.3.1' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.3.2' do
@@ -54,7 +54,7 @@ end
 
 workflow_task '1.3.3' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 step3_matchers = [
@@ -116,7 +116,7 @@ end
 
 workflow_task '1.4.1' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.4.2' do
@@ -151,7 +151,7 @@ end
 
 workflow_task '1.5.1' do
   cwd working
-  command 'chef-client --local-mode hello.rb --no-color --force-formatter'
+  command 'chef-client --local-mode hello.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.5.2' do
@@ -189,7 +189,7 @@ end
 
 workflow_task '1.6.1' do
   cwd working
-  command 'chef-client --local-mode goodbye.rb --no-color --force-formatter'
+  command 'chef-client --local-mode goodbye.rb --no-color --force-formatter --log_level warn'
 end
 
 workflow_task '1.6.2' do

--- a/cookbooks/learn-the-basics-windows/recipes/lesson2.rb
+++ b/cookbooks/learn-the-basics-windows/recipes/lesson2.rb
@@ -38,13 +38,13 @@ end
 # Run chef-client.
 workflow_task '2.1.1' do
   cwd working
-  command 'chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 # Run chef-client again.
 workflow_task '2.1.2' do
   cwd working
-  command 'chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 f2_1_1 = stdout_file(cache, '2.1.1')
@@ -90,7 +90,7 @@ end
 # Run chef-client.
 workflow_task '2.2.1' do
   cwd working
-  command 'chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 f2_2_1 = stdout_file(cache, '2.2.1')
@@ -138,7 +138,7 @@ end
 # Run chef-client.
 workflow_task '2.3.1' do
   cwd working
-  command 'chef-client --local-mode webserver.rb --no-color --force-formatter'
+  command 'chef-client --local-mode webserver.rb --no-color --force-formatter --log_level warn'
 end
 
 f2_3_1 = stdout_file(cache, '2.3.1')

--- a/cookbooks/learn-the-basics-windows/recipes/lesson3.rb
+++ b/cookbooks/learn-the-basics-windows/recipes/lesson3.rb
@@ -115,7 +115,7 @@ end
 # Run chef-client.
 workflow_task '3.4.1' do
   cwd repo
-  command "chef-client --local-mode --runlist 'recipe[learn_chef_iis]' --no-color --force-formatter"
+  command "chef-client --local-mode --runlist 'recipe[learn_chef_iis]' --no-color --force-formatter --log_level warn"
 end
 
 f3_4_1 = stdout_file(cache, '3.4.1')


### PR DESCRIPTION
Rather than relying on `--force-formatter`, which is buggy in Chef 12, use the specific log level our tests are written against (`:warn`).

Signed-off-by: Tom Duffield <tom@chef.io>