### PR TITLE
Ensure that properties can be nil

### DIFF
--- a/cookbooks/workflow/resources/task.rb
+++ b/cookbooks/workflow/resources/task.rb
@@ -8,7 +8,7 @@ property :command, String, required: true
 # the directory to run the command.
 property :cwd, String, required: true
 # directory to write output to.
-property :cache, String, required: false, default: nil
+property :cache, [String, nil], required: false, default: nil
 # the shell to run the command from. options are :bash and :powershell.
 property :shell, Symbol, required: false, default: :current
 # a Hash of environment variables to set before the command is run.

--- a/cookbooks/workflow/resources/task_options.rb
+++ b/cookbooks/workflow/resources/task_options.rb
@@ -1,7 +1,7 @@
 include LearnChef::Workflow
 
 # directory to write output to.
-property :cache, String, required: false, default: nil
+property :cache, [String, nil], required: false, default: nil
 # the shell to run the command from. options are :bash and :powershell.
 property :shell, Symbol, required: false, default: :bash
 # a Hash of environment variables to set before the command is run.


### PR DESCRIPTION
Chef 13 requires that nil properties are marked as such